### PR TITLE
quick fix output filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ version=0.9.0
 
 all: release
 
+appstore: release
+
 npm-init:
 	npm install
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "artificialowl/related_resources",
+  "name": "nextcloud/related_resources",
   "description": "RelatedResources App",
   "minimum-stability": "stable",
   "license": "agpl",

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -41,7 +41,7 @@ class LoadSidebarScript implements IEventListener {
 			return;
 		}
 
-		Util::addScript(Application::APP_ID, 'related_resources-main');
+		Util::addScript(Application::APP_ID, 'related_resources');
 		Util::addStyle(Application::APP_ID, 'icons');
 	}
 }

--- a/webpack.js
+++ b/webpack.js
@@ -14,4 +14,9 @@ webpackConfig.stats = {
 	modules: true,
 }
 
+webpackConfig.output = {
+	path: path.resolve('./js'),
+	filename: 'related_resources.js',
+}
+
 module.exports = webpackConfig


### PR DESCRIPTION
it seems that if the appid contains an underscore, the `apps/` folder is not included in the path to the Js by the addScript method.

This will set another/static output filename to webpack