### PR TITLE
Enable by default

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,6 +11,7 @@
 	<licence>agpl</licence>
 	<author>Maxence Lange</author>
 	<namespace>RelatedResources</namespace>
+	<default_enable/>
 	<documentation>
 		<admin>https://github.com/nextcloud/related_resources/</admin>
 	</documentation>


### PR DESCRIPTION
Because this is the replacement for projects which was also always visible by default.
