### PR TITLE
alternate route for complex itemid

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -2,7 +2,8 @@
 
 return [
 	'ocs' => [
-		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET']
+		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET'],
+		['name' => 'Api#getRelatedAlternate', 'url' => '/related/{providerId}', 'verb' => 'GET']
 	],
 	'routes' => []
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -2,6 +2,7 @@
 
 return [
 	'ocs' => [
+		// TODO remove this route for NC26
 		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET'],
 		['name' => 'Api#getRelatedAlternate', 'url' => '/related/{providerId}', 'verb' => 'GET']
 	],

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -117,4 +117,17 @@ class ApiController extends OcsController {
 			);
 		}
 	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $providerId
+	 * @param string $itemId
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function getRelatedAlternate(string $providerId, string $itemId): DataResponse {
+		return $this->getRelatedResources($providerId, $itemId);
+	}
 }


### PR DESCRIPTION
```
curl -X GET "https://cloud.example.net/ocs/v2.php/apps/related_resources/related/calendar?itemId=principals/users/user:test&format=json" -u "user:password" -H "OCS-ApiRequest: true" 
```