### PR TITLE
Revert "[stable25] alternate route for complex itemid"

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -2,9 +2,7 @@
 
 return [
 	'ocs' => [
-		// TODO remove this route for NC26
-		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET'],
-		['name' => 'Api#getRelatedAlternate', 'url' => '/related/{providerId}', 'verb' => 'GET']
+		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET']
 	],
 	'routes' => []
 ];

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -117,17 +117,4 @@ class ApiController extends OcsController {
 			);
 		}
 	}
-
-	/**
-	 * @NoAdminRequired
-	 *
-	 * @param string $providerId
-	 * @param string $itemId
-	 *
-	 * @return DataResponse
-	 * @throws OCSException
-	 */
-	public function getRelatedAlternate(string $providerId, string $itemId): DataResponse {
-		return $this->getRelatedResources($providerId, $itemId);
-	}
 }


### PR DESCRIPTION
Reverts nextcloud/related_resources#125

It was merged too early (after RC freeze)