### PR TITLE
Revert "Revert "[stable25] alternate route for complex itemid""

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -2,7 +2,9 @@
 
 return [
 	'ocs' => [
-		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET']
+		// TODO remove this route for NC26
+		['name' => 'Api#getRelatedResources', 'url' => '/related/{providerId}/{itemId}', 'verb' => 'GET'],
+		['name' => 'Api#getRelatedAlternate', 'url' => '/related/{providerId}', 'verb' => 'GET']
 	],
 	'routes' => []
 ];

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -117,4 +117,17 @@ class ApiController extends OcsController {
 			);
 		}
 	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $providerId
+	 * @param string $itemId
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function getRelatedAlternate(string $providerId, string $itemId): DataResponse {
+		return $this->getRelatedResources($providerId, $itemId);
+	}
 }


### PR DESCRIPTION
Revert https://github.com/nextcloud/related_resources/pull/134 after RC phase

The TODO is removed in https://github.com/nextcloud/related_resources/pull/133