### PR TITLE
Fix groupfolder icon color

### DIFF
--- a/lib/RelatedResourceProviders/GroupFoldersRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/GroupFoldersRelatedResourceProvider.php
@@ -135,7 +135,10 @@ class GroupFoldersRelatedResourceProvider implements IRelatedResourceProvider {
 
 		$related->setIcon(
 			$this->urlGenerator->getAbsoluteURL(
-				$this->urlGenerator->imagePath('groupfolders', 'app-dark.svg')
+				$this->urlGenerator->imagePath(
+					'groupfolders',
+					'app.svg'
+				)
 			)
 		);
 


### PR DESCRIPTION
Provide the light app icon to be consistent with other resource providers, color inversion is then handled on the frontend

### Requires

- [x] https://github.com/nextcloud/groupfolders/pull/2390

### Screenshots

Before | After
--- | ---
![image](https://github.com/nextcloud/related_resources/assets/24800714/7613b905-1af5-4b90-9eef-f83944ec3c97) | ![image](https://github.com/nextcloud/related_resources/assets/24800714/c8b7235a-fde8-4fbb-aa3b-9f9c01b9f814)