### PR TITLE
single init circlesmanager

### DIFF
--- a/lib/IRelatedResourceProvider.php
+++ b/lib/IRelatedResourceProvider.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 
 namespace OCA\RelatedResources;
 
+use OCA\Circles\CirclesManager;
 use OCA\Circles\Model\FederatedUser;
 
 interface IRelatedResourceProvider {
@@ -46,11 +47,12 @@ interface IRelatedResourceProvider {
 	/**
 	 * convert item to IRelatedResource, based on available shares
 	 *
+	 * @param CirclesManager $circlesManager
 	 * @param string $itemId
 	 *
 	 * @return IRelatedResource|null
 	 */
-	public function getRelatedFromItem(string $itemId): ?IRelatedResource;
+	public function getRelatedFromItem(CirclesManager $circlesManager, string $itemId): ?IRelatedResource;
 
 	/**
 	 * returns itemIds (as string) the entity have access to
@@ -64,9 +66,10 @@ interface IRelatedResourceProvider {
 	/**
 	 * improve a related resource before sending result to front-end.
 	 *
+	 * @param CirclesManager $circlesManager
 	 * @param IRelatedResource $entry
 	 *
 	 * @return void
 	 */
-	public function improveRelatedResource(IRelatedResource $entry): void;
+	public function improveRelatedResource(CirclesManager $circlesManager, IRelatedResource $entry): void;
 }

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -27,8 +27,8 @@ declare(strict_types=1);
 
 namespace OCA\RelatedResources\Listener;
 
-use OCA\RelatedResources\AppInfo\Application;
 use OCA\Files\Event\LoadSidebar;
+use OCA\RelatedResources\AppInfo\Application;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;

--- a/lib/Service/RelatedService.php
+++ b/lib/Service/RelatedService.php
@@ -226,7 +226,7 @@ class RelatedService {
 		}
 
 		$result = $this->getRelatedResourceProvider($providerId)
-					   ->getRelatedFromItem($itemId);
+					   ->getRelatedFromItem($this->circlesManager, $itemId);
 
 		$this->logger->debug('get related to ' . $providerId . '.' . $itemId . ' - ' . json_encode($result));
 
@@ -470,7 +470,7 @@ class RelatedService {
 	private function improveResult(array $result): array {
 		foreach ($result as $entry) {
 			$this->getRelatedResourceProvider($entry->getProviderId())
-				 ->improveRelatedResource($entry);
+				 ->improveRelatedResource($this->circlesManager, $entry);
 		}
 
 		return $result;


### PR DESCRIPTION
This PR change the way `CirclesManager` is loaded.
The idea is to load it once from the ResourceService, instead of loading it from each `resource provider`.

The reason is that it seems that, on overloaded system, resource provider are reload when calling get
On some loaded system, it looks like that resource provider are reload from scratch during `getRelatedResourceProviders()` (garbage collector ?)