### PR TITLE
new API param resourceType

### DIFF
--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -88,12 +88,13 @@ class Test extends Base {
 	protected function configure() {
 		parent::configure();
 		$this->setName('related:test')
-			 ->setHidden(!$this->config->getSystemValueBool('debug'))
-			 ->setDescription('returns related resource to a share')
-			 ->addArgument('userId', InputArgument::REQUIRED, 'user\'s point of view')
-			 ->addArgument('providerId', InputArgument::REQUIRED, 'Provider Id (ie. files)')
-			 ->addOption('clear-cache', '', InputOption::VALUE_NONE, 'clear cache')
-			 ->addArgument('itemId', InputArgument::REQUIRED, 'Item Id');
+			->setHidden(!$this->config->getSystemValueBool('debug'))
+			->setDescription('returns related resource to a share')
+			->addArgument('userId', InputArgument::REQUIRED, 'user\'s point of view')
+			->addArgument('providerId', InputArgument::REQUIRED, 'Provider Id (ie. files)')
+			->addOption('clear-cache', '', InputOption::VALUE_NONE, 'clear cache')
+			->addOption('resource-type', '', InputOption::VALUE_REQUIRED, 'limit to a type of resources', '')
+			->addArgument('itemId', InputArgument::REQUIRED, 'Item Id');
 	}
 
 
@@ -130,7 +131,7 @@ class Test extends Base {
 		$circleManager->startSession($circleManager->getLocalFederatedUser($userId));
 
 		$this->displayRecipients($providerId, $itemId);
-		$this->displayRelated($providerId, $itemId, ($input->getOption('output') === 'json'));
+		$this->displayRelated($providerId, $itemId, $input->getOption('resource-type'), ($input->getOption('output') === 'json'));
 
 		return 0;
 	}
@@ -148,8 +149,8 @@ class Test extends Base {
 	}
 
 
-	private function displayRelated(string $providerId, string $itemId, bool $json): void {
-		$result = $this->relatedService->getRelatedToItem($providerId, $itemId);
+	private function displayRelated(string $providerId, string $itemId, string $resourceType, bool $json): void {
+		$result = $this->relatedService->getRelatedToItem($providerId, $itemId, -1, $resourceType);
 
 		$output = new ConsoleOutput();
 		if ($json) {

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -84,11 +84,11 @@ class ApiController extends OcsController {
 	 *
 	 * @param string $providerId
 	 * @param string $itemId
-	 *
+	 * @param string $resourceType
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function getRelatedResources(string $providerId, string $itemId): DataResponse {
+	public function getRelatedResources(string $providerId, string $itemId, string $resourceType = ''): DataResponse {
 		if (is_null($this->circlesManager)) {
 			$this->logger->info('RelatedResources require Circles');
 
@@ -101,7 +101,8 @@ class ApiController extends OcsController {
 			$result = $this->relatedService->getRelatedToItem(
 				$providerId,
 				$itemId,
-				$this->configService->getAppValueInt(ConfigService::RESULT_MAX)
+				$this->configService->getAppValueInt(ConfigService::RESULT_MAX),
+				$resourceType
 			);
 
 			// cleanData on result, to not send useless data.

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -88,20 +88,26 @@ class ApiController extends OcsController {
 	 * @return DataResponse
 	 * @throws OCSException
 	 */
-	public function getRelatedResources(string $providerId, string $itemId, string $resourceType = ''): DataResponse {
+	public function getRelatedResources(
+		string $providerId,
+		string $itemId,
+		int $limit = 0,
+		string $resourceType = ''
+	): DataResponse {
 		if (is_null($this->circlesManager)) {
 			$this->logger->info('RelatedResources require Circles');
 
 			return new DataResponse([]);
 		}
 
+		$limit = ($limit > 0) ? $limit : $this->configService->getAppValueInt(ConfigService::RESULT_MAX);
 		try {
 			$this->circlesManager->startSession();
 
 			$result = $this->relatedService->getRelatedToItem(
 				$providerId,
 				$itemId,
-				$this->configService->getAppValueInt(ConfigService::RESULT_MAX),
+				$limit,
 				$resourceType
 			);
 

--- a/lib/Service/RelatedService.php
+++ b/lib/Service/RelatedService.php
@@ -45,8 +45,8 @@ use OCA\RelatedResources\LinkWeightCalculators\AncienShareWeightCalculator;
 use OCA\RelatedResources\LinkWeightCalculators\KeywordWeightCalculator;
 use OCA\RelatedResources\LinkWeightCalculators\TimeWeightCalculator;
 use OCA\RelatedResources\Model\RelatedResource;
-use OCA\RelatedResources\RelatedResourceProviders\CalendarRelatedResourceProvider;
 use OCA\RelatedResources\RelatedResourceProviders\AccountRelatedResourceProvider;
+use OCA\RelatedResources\RelatedResourceProviders\CalendarRelatedResourceProvider;
 use OCA\RelatedResources\RelatedResourceProviders\DeckRelatedResourceProvider;
 use OCA\RelatedResources\RelatedResourceProviders\FilesRelatedResourceProvider;
 use OCA\RelatedResources\RelatedResourceProviders\GroupFoldersRelatedResourceProvider;
@@ -114,12 +114,17 @@ class RelatedService {
 	 * @return IRelatedResource[]
 	 * @throws RelatedResourceProviderNotFound
 	 */
-	public function getRelatedToItem(string $providerId, string $itemId, int $chunk = -1): array {
+	public function getRelatedToItem(
+		string $providerId,
+		string $itemId,
+		int $chunk = -1,
+		string $resourceType = ''
+	): array {
 		if ($this->circlesManager === null) {
 			return [];
 		}
 
-		$result = $this->retrieveRelatedToItem($providerId, $itemId);
+		$result = $this->retrieveRelatedToItem($providerId, $itemId, $resourceType);
 
 		usort($result, function (IRelatedResource $r1, IRelatedResource $r2): int {
 			$a = $r1->getScore();
@@ -141,7 +146,11 @@ class RelatedService {
 	 * @return IRelatedResource[]
 	 * @throws RelatedResourceProviderNotFound
 	 */
-	private function retrieveRelatedToItem(string $providerId, string $itemId): array {
+	private function retrieveRelatedToItem(
+		string $providerId,
+		string $itemId,
+		string $resourceType = ''
+	): array {
 		$this->logger->debug('retrieving related to item ' . $providerId . '.' . $itemId);
 
 		try {
@@ -158,8 +167,14 @@ class RelatedService {
 			$recipients = $current->getVirtualGroup();
 		}
 
+		if ($resourceType === '') {
+			$providers = $this->getRelatedResourceProviders();
+		} else {
+			$providers = [$this->getRelatedResourceProvider($resourceType)];
+		}
+
 		$result = [];
-		foreach ($this->getRelatedResourceProviders() as $provider) {
+		foreach ($providers as $provider) {
 			$known = [];
 			if ($provider->getProviderId() === $providerId) {
 				$known[] = $current->getItemId();
@@ -528,7 +543,14 @@ class RelatedService {
 
 		try {
 			$providers[] = Server::get(FilesRelatedResourceProvider::class);
-		} catch (NotFoundExceptionInterface | ContainerExceptionInterface $e) {
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+			$this->logger->notice($e->getMessage());
+		}
+
+
+		try {
+			$providers[] = Server::get(AccountRelatedResourceProvider::class);
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 			$this->logger->notice($e->getMessage());
 		}
 
@@ -563,12 +585,6 @@ class RelatedService {
 				$this->logger->notice($e->getMessage());
 			}
 		}
-
-			try {
-				$providers[] = Server::get(AccountRelatedResourceProvider::class);
-			} catch (NotFoundExceptionInterface | ContainerExceptionInterface $e) {
-				$this->logger->notice($e->getMessage());
-			}
 
 		return $providers;
 	}


### PR DESCRIPTION
limit related resource to a specific type

After sharing a file with `test1`, I check the related resource between my account and `test1`:
![image](https://github.com/nextcloud/related_resources/assets/1038617/3b276a4a-46b0-4de8-95ea-bff44318b684)
