### PR TITLE
returns resources preview

### DIFF
--- a/lib/IRelatedResource.php
+++ b/lib/IRelatedResource.php
@@ -52,6 +52,10 @@ interface IRelatedResource {
 
 	public function getIcon(): string;
 
+	public function setPreview(string $preview): self;
+
+	public function getPreview(): string;
+
 	public function setUrl(string $url): self;
 
 	public function getUrl(): string;

--- a/lib/Model/RelatedResource.php
+++ b/lib/Model/RelatedResource.php
@@ -63,6 +63,7 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 	private string $subtitle = '';
 	private string $tooltip = '';
 	private string $icon = '';
+	private string $preview = '';
 	private string $url = '';
 	private int $range = 0;
 	private array $virtualGroup = [];
@@ -139,6 +140,16 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 
 	public function getIcon(): string {
 		return $this->icon;
+	}
+
+	public function setPreview(string $preview): self {
+		$this->preview = $preview;
+
+		return $this;
+	}
+
+	public function getPreview(): string {
+		return $this->preview;
 	}
 
 
@@ -270,6 +281,7 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 		$this->setSubtitle($this->get('subtitle', $data));
 		$this->setTooltip($this->get('tooltip', $data));
 		$this->setIcon($this->get('icon', $data));
+		$this->setPreview($this->get('preview', $data));
 		$this->setUrl($this->get('url', $data));
 		$this->setScore($this->getInt('score', $data));
 		$this->setAsGroupShared($this->getBool('groupShared', $data));
@@ -290,6 +302,7 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 			'subtitle' => $this->getSubtitle(),
 			'tooltip' => $this->getTooltip(),
 			'icon' => $this->getIcon(),
+			'preview' => $this->getPreview(),
 			'url' => $this->getUrl(),
 			'score' => $this->getScore(),
 			'groupShared' => $this->isGroupShared(),
@@ -303,8 +316,8 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 
 	public static function cleanData(array $arr): array {
 		static $acceptedKeys = [
-			'providerId', 'itemId', 'title', 'subtitle', 'tooltip', 'url', 'icon', 'score',
-			'improvements'
+			'providerId', 'itemId', 'title', 'subtitle', 'tooltip', 'url',
+			'icon', 'preview', 'score', 'improvements'
 		];
 
 		$new = [];

--- a/lib/RelatedResourceProviders/FilesRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/FilesRelatedResourceProvider.php
@@ -166,6 +166,12 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 				)
 			)
 		);
+		$related->setPreview(
+			$this->urlGenerator->linkToRouteAbsolute(
+				'core.Preview.getPreviewByFileId',
+				['x' => 64, 'y' => 64, 'fileId' => $share->getFileId()]
+			)
+		);
 
 		$related->setUrl(
 			$this->urlGenerator->linkToRouteAbsolute('files.View.showFile', ['fileid' => $share->getFileId()])

--- a/lib/RelatedResourceProviders/TalkRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/TalkRelatedResourceProvider.php
@@ -179,7 +179,13 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 						)
 					)
 				)
-				->setUrl($url);
+			->setPreview(
+				$this->urlGenerator->linkToOCSRouteAbsolute(
+					'spreed.Avatar.getAvatar',
+					['token' => $share->getToken(), 'apiVersion' => 'v1']
+				)
+			)
+			->setUrl($url);
 
 		$keywords = preg_split('/[\/_\-. ]/', ltrim(strtolower($share->getRoomName()), '/'));
 		if (is_array($keywords)) {


### PR DESCRIPTION
add a `'preview' entry in the result json, that should contains a preview of the related resource