### PR TITLE
fix: Skip aggregating resources that are already listed in team resources

### DIFF
--- a/lib/RelatedResourceProviders/DeckRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/DeckRelatedResourceProvider.php
@@ -113,8 +113,8 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 				break;
 
 			case Member::TYPE_CIRCLE:
-				$shares = $this->deckSharesRequest->getDeckAvailableToCircle($entity->getSingleId());
-				break;
+				// We skip circle shares for related resources as they are covered by team resources
+				return [];
 
 			default:
 				return [];

--- a/lib/RelatedResourceProviders/FilesRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/FilesRelatedResourceProvider.php
@@ -125,8 +125,8 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 				break;
 
 			case Member::TYPE_CIRCLE:
-				$shares = $this->filesShareRequest->getSharesToCircle($entity->getSingleId());
-				break;
+				// We skip circle shares for related resources as they are covered by team resources
+				return [];
 
 			default:
 				return [];

--- a/lib/RelatedResourceProviders/TalkRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/TalkRelatedResourceProvider.php
@@ -143,8 +143,8 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 				break;
 
 			case Member::TYPE_CIRCLE:
-				$shares = $this->talkRoomRequest->getRoomsAvailableToCircle($entity->getSingleId());
-				break;
+				// We skip circle shares for related resources as they are covered by team resources
+				return [];
 
 			default:
 				return [];


### PR DESCRIPTION
We already list direct shares with teams in the team resources so we may skip those in the related resources which aggregates other matches by user or group shares still.