### PR TITLE
fix(db): replace execute with executeQuery

### DIFF
--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -1004,7 +1004,7 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws RowNotFoundException
 	 */
 	public function getRow(callable $method, string $object = '', array $params = []): IQueryRow {
-		$cursor = $this->execute();
+		$cursor = $this->executeQuery();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
 
@@ -1025,7 +1025,7 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 */
 	public function getRows(callable $method, string $object = '', array $params = []): array {
 		$rows = [];
-		$cursor = $this->execute();
+		$cursor = $this->executeQuery();
 		while ($data = $cursor->fetch()) {
 			try {
 				$rows[] = $method($data, $this, $object, $params);


### PR DESCRIPTION
`execute` is gone since 33.

The error message from related resources is gone, yet on my dev setup I'm not seeing any related resources in my smoke test. 

| B | A |
| --- | --- |
| <img width="584" height="747" alt="image" src="https://github.com/user-attachments/assets/08b37790-570e-419f-895d-ba2636443f2a" /> | <img width="525" height="889" alt="image" src="https://github.com/user-attachments/assets/71288c13-f020-466f-ad42-0c8748a169ac" /> |


Ref: https://github.com/nextcloud/server/pull/55720