### PR TITLE
[stable34] ci(psalm): Fix nextcloud/ocp update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"classmap-authoritative": true,
 		"autoloader-suffix": "RelatedResources",
 		"platform": {
-			"php": "8.1"
+			"php": "8.2"
 		}
 	},
 	"authors": [
@@ -37,7 +37,7 @@
 		"phpunit/phpunit": "^10.5",
 		"vimeo/psalm": "^5.10",
 		"nextcloud/coding-standard": "^1.0",
-		"nextcloud/ocp": "dev-master"
+		"nextcloud/ocp": "dev-stable34"
 	},
 	"autoload-dev": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84c57325779e3ccbcbcc8b5419e95be0",
+    "content-hash": "c0bf97209be5c7f2bff822d308a7587e",
     "packages": [],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.4",
+            "version": "v2.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d"
+                "reference": "d7dda98dae26e56f3f6fcfbf1c1f819c9a993207"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
-                "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/d7dda98dae26e56f3f6fcfbf1c1f819c9a993207",
+                "reference": "d7dda98dae26e56f3f6fcfbf1c1f819c9a993207",
                 "shasum": ""
             },
             "require": {
@@ -34,11 +34,6 @@
                 "vimeo/psalm": "^3.12"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "lib/functions.php",
@@ -86,7 +81,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.4"
+                "source": "https://github.com/amphp/amp/tree/v2.6.5"
             },
             "funding": [
                 {
@@ -94,7 +89,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-21T18:52:26+00:00"
+            "time": "2025-09-03T19:41:28+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -169,28 +164,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -228,7 +224,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -238,26 +234,22 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +301,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -319,13 +311,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -432,29 +420,30 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -462,7 +451,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -473,9 +462,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -524,16 +513,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "v1.5.2",
+            "version": "v1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
-                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
                 "shasum": ""
             },
             "require": {
@@ -574,22 +563,22 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
             },
-            "time": "2022-03-02T22:36:06+00:00"
+            "time": "2024-04-30T00:40:11+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "8520451a140d3f46ac33042715115e290cf5785f"
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/8520451a140d3f46ac33042715115e290cf5785f",
-                "reference": "8520451a140d3f46ac33042715115e290cf5785f",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
                 "shasum": ""
             },
             "require": {
@@ -599,10 +588,10 @@
                 "fidry/makefile": "^0.2.0",
                 "fidry/php-cs-fixer-config": "^1.1.2",
                 "phpstan/extension-installer": "^1.2.0",
-                "phpstan/phpstan": "^1.9.2",
-                "phpstan/phpstan-deprecation-rules": "^1.0.0",
-                "phpstan/phpstan-phpunit": "^1.2.2",
-                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^8.5.31 || ^9.5.26",
                 "webmozarts/strict-phpunit": "^7.5"
             },
@@ -629,7 +618,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.2.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
             },
             "funding": [
                 {
@@ -637,30 +626,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-06T10:04:20+00:00"
+            "time": "2025-08-14T07:29:31+00:00"
         },
         {
             "name": "kubawerlos/php-cs-fixer-custom-fixers",
-            "version": "v3.27.0",
+            "version": "v3.37.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
-                "reference": "d860473d16b906c7945206177edc7d112357a706"
+                "reference": "678df979ce743466b42ddb6eea46b3f4c9a7bade"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/d860473d16b906c7945206177edc7d112357a706",
-                "reference": "d860473d16b906c7945206177edc7d112357a706",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/678df979ce743466b42ddb6eea46b3f4c9a7bade",
+                "reference": "678df979ce743466b42ddb6eea46b3f4c9a7bade",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "ext-tokenizer": "*",
-                "friendsofphp/php-cs-fixer": "^3.61.1",
+                "friendsofphp/php-cs-fixer": "^3.87",
                 "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6.22 || 10.5.45 || ^11.5.7"
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55"
             },
             "type": "library",
             "autoload": {
@@ -681,7 +670,7 @@
             "description": "A set of custom fixers for PHP CS Fixer",
             "support": {
                 "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
-                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.27.0"
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.37.2"
             },
             "funding": [
                 {
@@ -689,7 +678,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-10T20:53:07+00:00"
+            "time": "2026-05-12T16:22:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -804,16 +793,16 @@
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "v1.4.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
-                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011"
+                "reference": "80547a93236fbb9c783e05f0f0899043851b0dba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/8e06808c1423e9208d63d1bd205b9a38bd400011",
-                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011",
+                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/80547a93236fbb9c783e05f0f0899043851b0dba",
+                "reference": "80547a93236fbb9c783e05f0f0899043851b0dba",
                 "shasum": ""
             },
             "require": {
@@ -843,36 +832,36 @@
             ],
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/v1.4.0"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.5.0"
             },
-            "time": "2025-06-19T12:27:27+00:00"
+            "time": "2026-05-19T18:30:09+00:00"
         },
         {
             "name": "nextcloud/ocp",
-            "version": "dev-master",
+            "version": "dev-stable34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "dfcf4583e63fea987ad58585bb5f11c65cc05e82"
+                "reference": "81cbb2c594afe0fa978885bf7accd0440199520a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dfcf4583e63fea987ad58585bb5f11c65cc05e82",
-                "reference": "dfcf4583e63fea987ad58585bb5f11c65cc05e82",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/81cbb2c594afe0fa978885bf7accd0440199520a",
+                "reference": "81cbb2c594afe0fa978885bf7accd0440199520a",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
+                "php": "~8.2 || ~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
-                "psr/log": "^1.1.4"
+                "psr/http-client": "^1.0.3",
+                "psr/log": "^3.0.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "31.0.0-dev"
+                    "dev-stable34": "34.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -883,14 +872,18 @@
                 {
                     "name": "Christoph Wurst",
                     "email": "christoph@winzerhof-wurst.at"
+                },
+                {
+                    "name": "Joas Schilling",
+                    "email": "coding@schilljs.com"
                 }
             ],
-            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
+            "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2024-10-05T00:42:05+00:00"
+            "time": "2026-07-16T01:28:13+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1063,16 +1056,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.75.0",
+            "version": "v3.95.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "eea219a577085bd13ff0cb644a422c20798316c7"
+                "reference": "64a33558b1b581470c8c8489048efaf9ceeb8415"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/eea219a577085bd13ff0cb644a422c20798316c7",
-                "reference": "eea219a577085bd13ff0cb644a422c20798316c7",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/64a33558b1b581470c8c8489048efaf9ceeb8415",
+                "reference": "64a33558b1b581470c8c8489048efaf9ceeb8415",
                 "shasum": ""
             },
             "require": {
@@ -1109,9 +1102,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.75.0"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.15"
             },
-            "time": "2025-03-31T18:45:02+00:00"
+            "time": "2026-07-15T09:52:14+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1168,16 +1161,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.4.1",
+            "version": "5.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c"
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
                 "shasum": ""
             },
             "require": {
@@ -1186,17 +1179,17 @@
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7",
-                "webmozart/assert": "^1.9.1"
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.5",
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "vimeo/psalm": "^5.13"
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -1226,29 +1219,29 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.4.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
             },
-            "time": "2024-05-21T05:55:05+00:00"
+            "time": "2026-03-18T20:47:46+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.8.2",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c"
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/153ae662783729388a584b4361f2545e4d841e3c",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.13"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -1284,36 +1277,36 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
-            "time": "2024-02-23T11:10:43+00:00"
+            "time": "2025-11-21T15:09:14+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.30.1",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "51b95ec8670af41009e2b2b56873bad96682413e"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/51b95ec8670af41009e2b2b56873bad96682413e",
-                "reference": "51b95ec8670af41009e2b2b56873bad96682413e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^5.3.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -1331,9 +1324,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.30.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2024-09-07T20:13:05+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1658,24 +1651,24 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.62",
+            "version": "10.5.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3f7dd5066ebde5809296a81f0b19e8b00e5aab49"
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3f7dd5066ebde5809296a81f0b19e8b00e5aab49",
-                "reference": "3f7dd5066ebde5809296a81f0b19e8b00e5aab49",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
-                "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
@@ -1739,31 +1732,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.62"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-01-27T05:32:38+00:00"
+            "time": "2026-07-06T14:50:35+00:00"
         },
         {
             "name": "psr/clock",
@@ -1917,31 +1894,136 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "1.1.4",
+            "name": "psr/http-client",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1962,9 +2044,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2921,16 +3003,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.3.0",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "f56b220fe2db1ade4c88098d83413ebdfc3bf876"
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/f56b220fe2db1ade4c88098d83413ebdfc3bf876",
-                "reference": "f56b220fe2db1ade4c88098d83413ebdfc3bf876",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/88b2f3852a922dd73177a68938f8eb2ec70c7224",
+                "reference": "88b2f3852a922dd73177a68938f8eb2ec70c7224",
                 "shasum": ""
             },
             "require": {
@@ -2973,7 +3055,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.3.0"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.4"
             },
             "funding": [
                 {
@@ -2985,51 +3067,51 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-05-01T10:20:27+00:00"
+            "time": "2025-12-15T09:00:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.22",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
-                "reference": "7d29659bc3c9d8e9a34e2c3414ef9e9e003e6cf3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^7.2|^8.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3063,7 +3145,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.22"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3075,24 +3157,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-07T07:05:04+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -3105,7 +3191,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3130,7 +3216,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3142,33 +3228,37 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.13",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "4856c9cf585d5a0313d8d35afd681a526f038dd3"
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4856c9cf585d5a0313d8d35afd681a526f038dd3",
-                "reference": "4856c9cf585d5a0313d8d35afd681a526f038dd3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^5.4|^6.4|^7.0"
+                "symfony/process": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3196,7 +3286,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.13"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -3208,24 +3298,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:07:50+00:00"
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.32.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -3275,7 +3369,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3287,24 +3381,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.32.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -3353,7 +3451,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -3365,24 +3463,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.32.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -3434,7 +3536,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -3446,24 +3548,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.32.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -3515,7 +3621,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -3527,24 +3633,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
-                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -3562,7 +3672,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -3598,7 +3708,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3610,30 +3720,35 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-25T09:37:31+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.21",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/73e2c6966a5aef1d4892873ed5322245295370c6",
-                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-grapheme": "~1.33",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
@@ -3641,11 +3756,11 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^6.2|^7.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3684,7 +3799,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.21"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -3696,11 +3811,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-18T15:23:29+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3827,11 +3946,11 @@
             "type": "project",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.x-dev",
-                    "dev-4.x": "4.x-dev",
-                    "dev-3.x": "3.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -3864,33 +3983,37 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.11.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
             },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
-                    "dev-master": "1.10-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3906,6 +4029,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
                 }
             ],
             "description": "Assertions to validate method input/output with nice error messages.",
@@ -3916,9 +4043,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],
@@ -3931,7 +4058,7 @@
     "platform": {},
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,14 +28,12 @@ use Throwable;
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'related_resources';
 
-
 	/**
 	 * @param array $params
 	 */
 	public function __construct(array $params = []) {
 		parent::__construct(self::APP_ID, $params);
 	}
-
 
 	/**
 	 * @param IRegistrationContext $context
@@ -45,7 +43,6 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(ShareCreatedEvent::class, FileShareUpdate::class);
 		$context->registerEventListener(ShareDeletedEvent::class, FileShareUpdate::class);
 	}
-
 
 	/**
 	 * @param IBootContext $context

--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -59,7 +59,6 @@ class Test extends Base {
 		$this->relatedService = $relatedService;
 	}
 
-
 	/**
 	 * @return void
 	 */
@@ -74,7 +73,6 @@ class Test extends Base {
 			->addOption('resource-type', '', InputOption::VALUE_REQUIRED, 'limit to a type of resources', '')
 			->addArgument('itemId', InputArgument::REQUIRED, 'Item Id');
 	}
-
 
 	/**
 	 * @param InputInterface $input
@@ -114,7 +112,6 @@ class Test extends Base {
 		return 0;
 	}
 
-
 	private function displayRecipients(string $providerId, string $itemId): void {
 		$result = $this->relatedService->getRelatedFromItem($providerId, $itemId);
 
@@ -125,7 +122,6 @@ class Test extends Base {
 		$output->writeln('<info>Recipients</info>: ' . json_encode($result->getRecipients()));
 		$output->writeln('');
 	}
-
 
 	private function displayRelated(string $providerId, string $itemId, string $resourceType, bool $json): void {
 		$result = $this->relatedService->getRelatedToItem($providerId, $itemId, -1, $resourceType);

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Controller;
 
@@ -30,7 +28,6 @@ use Psr\Log\LoggerInterface;
 
 class ApiController extends OcsController {
 	use TDeserialize;
-
 
 	private LoggerInterface $logger;
 	private IUserSession $userSession;
@@ -57,7 +54,6 @@ class ApiController extends OcsController {
 		} catch (ContainerExceptionInterface|AutoloadNotAllowedException $e) {
 		}
 	}
-
 
 	/**
 	 * @NoAdminRequired

--- a/lib/Db/CalendarShareRequest.php
+++ b/lib/Db/CalendarShareRequest.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -31,7 +29,6 @@ class CalendarShareRequest extends CalendarShareRequestBuilder {
 		return $this->getCalendarFromRequest($qb);
 	}
 
-
 	/**
 	 * @param int $calendarId
 	 *
@@ -44,7 +41,6 @@ class CalendarShareRequest extends CalendarShareRequestBuilder {
 
 		return $this->getSharesFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $singleId
@@ -64,7 +60,6 @@ class CalendarShareRequest extends CalendarShareRequestBuilder {
 		return $this->getCalendarsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $groupName
 	 *
@@ -82,7 +77,6 @@ class CalendarShareRequest extends CalendarShareRequestBuilder {
 
 		return $this->getCalendarsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $userName

--- a/lib/Db/CoreQueryBuilder.php
+++ b/lib/Db/CoreQueryBuilder.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -82,14 +80,12 @@ class CoreQueryBuilder {
 		]
 	];
 
-
 	/**
 	 * @param ConfigService $configService
 	 */
 	public function __construct(ConfigService $configService) {
 		$this->configService = $configService;
 	}
-
 
 	/**
 	 * @return CoreRequestBuilder

--- a/lib/Db/CoreRequestBuilder.php
+++ b/lib/Db/CoreRequestBuilder.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 

--- a/lib/Db/DeckRequest.php
+++ b/lib/Db/DeckRequest.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -30,7 +28,6 @@ class DeckRequest extends DeckRequestBuilder {
 		return $this->getDeckFromRequest($qb);
 	}
 
-
 	/**
 	 * @param int $boardId
 	 *
@@ -42,7 +39,6 @@ class DeckRequest extends DeckRequestBuilder {
 
 		return $this->getSharesFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $singleId
@@ -62,7 +58,6 @@ class DeckRequest extends DeckRequestBuilder {
 		return $this->getDecksFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $groupName
 	 *
@@ -80,7 +75,6 @@ class DeckRequest extends DeckRequestBuilder {
 
 		return $this->getDecksFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $userName

--- a/lib/Db/FilesShareRequest.php
+++ b/lib/Db/FilesShareRequest.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -27,7 +25,6 @@ class FilesShareRequest extends FilesShareRequestBuilder {
 		return $this->getItemsFromRequest($qb);
 	}
 
-
 	/**
 	 * @param array $itemIds
 	 *
@@ -39,7 +36,6 @@ class FilesShareRequest extends FilesShareRequestBuilder {
 
 		return $this->getItemsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $singleId
@@ -66,7 +62,6 @@ class FilesShareRequest extends FilesShareRequestBuilder {
 
 		return $this->getItemsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $userId

--- a/lib/Db/FilesShareRequestBuilder.php
+++ b/lib/Db/FilesShareRequestBuilder.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -26,7 +24,6 @@ class FilesShareRequestBuilder extends CoreQueryBuilder {
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param CoreRequestBuilder $qb

--- a/lib/Db/TalkRoomRequest.php
+++ b/lib/Db/TalkRoomRequest.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -29,7 +27,6 @@ class TalkRoomRequest extends TalkRoomRequestBuilder {
 		return $this->getRoomFromRequest($qb);
 	}
 
-
 	/**
 	 * @param string $token
 	 *
@@ -46,7 +43,6 @@ class TalkRoomRequest extends TalkRoomRequestBuilder {
 
 		return $this->getActorsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $singleId
@@ -65,7 +61,6 @@ class TalkRoomRequest extends TalkRoomRequestBuilder {
 
 		return $this->getRoomsFromRequest($qb);
 	}
-
 
 	/**
 	 * @param string $groupName

--- a/lib/Db/TalkRoomRequestBuilder.php
+++ b/lib/Db/TalkRoomRequestBuilder.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Db;
 
@@ -28,14 +26,12 @@ class TalkRoomRequestBuilder extends CoreQueryBuilder {
 		return $qb;
 	}
 
-
 	protected function getActorSelectSql(): CoreRequestBuilder {
 		$qb = $this->getQueryBuilder();
 		$qb->generateSelect(self::TABLE_TALK_ATTENDEE, self::$externalTables[self::TABLE_TALK_ATTENDEE]);
 
 		return $qb;
 	}
-
 
 	/**
 	 * @param CoreRequestBuilder $qb

--- a/lib/Exceptions/CacheNotFoundException.php
+++ b/lib/Exceptions/CacheNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/Exceptions/CalendarDataNotFoundException.php
+++ b/lib/Exceptions/CalendarDataNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/Exceptions/DeckDataNotFoundException.php
+++ b/lib/Exceptions/DeckDataNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/Exceptions/FilesShareNotFoundException.php
+++ b/lib/Exceptions/FilesShareNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/Exceptions/GroupFolderNotFoundException.php
+++ b/lib/Exceptions/GroupFolderNotFoundException.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\RelatedResources\Exceptions;
 
 use Exception;

--- a/lib/Exceptions/RelatedResourceNotFound.php
+++ b/lib/Exceptions/RelatedResourceNotFound.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/Exceptions/RelatedResourceProviderNotFound.php
+++ b/lib/Exceptions/RelatedResourceProviderNotFound.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/Exceptions/TalkDataNotFoundException.php
+++ b/lib/Exceptions/TalkDataNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Exceptions;
 

--- a/lib/ILinkWeightCalculator.php
+++ b/lib/ILinkWeightCalculator.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources;
 

--- a/lib/IRelatedResource.php
+++ b/lib/IRelatedResource.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources;
 

--- a/lib/IRelatedResourceProvider.php
+++ b/lib/IRelatedResourceProvider.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources;
 

--- a/lib/LinkWeightCalculators/AncienShareWeightCalculator.php
+++ b/lib/LinkWeightCalculators/AncienShareWeightCalculator.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -18,11 +17,9 @@ use OCA\RelatedResources\Tools\Traits\TArrayTools;
 class AncienShareWeightCalculator implements ILinkWeightCalculator {
 	use TArrayTools;
 
-
 	private static float $RATIO_5Y = 0.4;
 	private static float $RATIO_3Y = 0.7;
 	private static float $RATIO_1Y = 0.85;
-
 
 	/**
 	 * @inheritDoc

--- a/lib/LinkWeightCalculators/KeywordWeightCalculator.php
+++ b/lib/LinkWeightCalculators/KeywordWeightCalculator.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -17,7 +16,6 @@ use OCA\RelatedResources\Tools\Traits\TArrayTools;
 
 class KeywordWeightCalculator implements ILinkWeightCalculator {
 	use TArrayTools;
-
 
 	/**
 	 * @inheritDoc

--- a/lib/LinkWeightCalculators/TimeWeightCalculator.php
+++ b/lib/LinkWeightCalculators/TimeWeightCalculator.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\LinkWeightCalculators;
 

--- a/lib/Listener/LoadSidebarScript.php
+++ b/lib/Listener/LoadSidebarScript.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\RelatedResources\Listener;
 
 use OCA\Files\Event\LoadSidebar;

--- a/lib/Model/Calendar.php
+++ b/lib/Model/Calendar.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 

--- a/lib/Model/CalendarShare.php
+++ b/lib/Model/CalendarShare.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -46,7 +44,6 @@ class CalendarShare implements IQueryRow, JsonSerializable {
 		return $this->sharePrincipalUri;
 	}
 
-
 	/**
 	 * @param int $type
 	 *
@@ -82,7 +79,6 @@ class CalendarShare implements IQueryRow, JsonSerializable {
 	public function getUser(): string {
 		return $this->user;
 	}
-
 
 	public function importFromDatabase(array $data): IQueryRow {
 		$this->setCalendarId($this->getInt('resourceid', $data))

--- a/lib/Model/DeckBoard.php
+++ b/lib/Model/DeckBoard.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -26,7 +24,6 @@ class DeckBoard implements IQueryRow, JsonSerializable {
 	public function __construct() {
 	}
 
-
 	/**
 	 * @param int $boardId
 	 *
@@ -44,7 +41,6 @@ class DeckBoard implements IQueryRow, JsonSerializable {
 	public function getBoardId(): int {
 		return $this->boardId;
 	}
-
 
 	/**
 	 * @param string $boardName
@@ -81,7 +77,6 @@ class DeckBoard implements IQueryRow, JsonSerializable {
 	public function getOwner(): string {
 		return $this->owner;
 	}
-
 
 	/**
 	 * @param int $lastModified

--- a/lib/Model/DeckShare.php
+++ b/lib/Model/DeckShare.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -22,10 +20,8 @@ class DeckShare implements IQueryRow, JsonSerializable {
 	private int $recipientType = 0;
 	private string $recipientId = '';
 
-
 	public function __construct() {
 	}
-
 
 	/**
 	 * @param int $boardId
@@ -45,7 +41,6 @@ class DeckShare implements IQueryRow, JsonSerializable {
 		return $this->boardId;
 	}
 
-
 	/**
 	 * @param int $recipientType
 	 *
@@ -64,7 +59,6 @@ class DeckShare implements IQueryRow, JsonSerializable {
 		return $this->recipientType;
 	}
 
-
 	/**
 	 * @param string $recipientId
 	 *
@@ -82,7 +76,6 @@ class DeckShare implements IQueryRow, JsonSerializable {
 	public function getRecipientId(): string {
 		return $this->recipientId;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Model/FilesShare.php
+++ b/lib/Model/FilesShare.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -18,7 +16,6 @@ use OCA\RelatedResources\Tools\Traits\TArrayTools;
 
 class FilesShare implements IQueryRow, JsonSerializable {
 	use TArrayTools;
-
 
 	private string $sharedWith = '';
 	private int $shareType = 0;

--- a/lib/Model/RelatedResource.php
+++ b/lib/Model/RelatedResource.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -89,7 +87,6 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 		return $this->title;
 	}
 
-
 	public function setSubtitle(string $subtitle): IRelatedResource {
 		$this->subtitle = $subtitle;
 
@@ -100,7 +97,6 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 		return $this->subtitle;
 	}
 
-
 	public function setTooltip(string $tooltip): self {
 		$this->tooltip = $tooltip;
 
@@ -110,7 +106,6 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 	public function getTooltip(): string {
 		return $this->tooltip;
 	}
-
 
 	public function setIcon(string $icon): self {
 		$this->icon = $icon;
@@ -131,7 +126,6 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 	public function getPreview(): string {
 		return $this->preview;
 	}
-
 
 	public function setUrl(string $url): IRelatedResource {
 		$this->url = $url;
@@ -232,7 +226,6 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 		return $this->groupShared;
 	}
 
-
 	public function getImprovements(): array {
 		return $this->improvements;
 	}
@@ -252,7 +245,6 @@ class RelatedResource implements IRelatedResource, IDeserializable, JsonSerializ
 	public function getCurrentQuality(): array {
 		return $this->currentQuality;
 	}
-
 
 	public function import(array $data): IDeserializable {
 		$this->setProviderId($this->get('providerId', $data));

--- a/lib/Model/TalkActor.php
+++ b/lib/Model/TalkActor.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -59,7 +57,6 @@ class TalkActor implements IQueryRow, JsonSerializable {
 	public function getActorId(): string {
 		return $this->actorId;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/Model/TalkRoom.php
+++ b/lib/Model/TalkRoom.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Model;
 
@@ -26,7 +24,6 @@ class TalkRoom implements IQueryRow, JsonSerializable {
 	public function __construct() {
 	}
 
-
 	/**
 	 * @param int $roomId
 	 *
@@ -44,7 +41,6 @@ class TalkRoom implements IQueryRow, JsonSerializable {
 	public function getRoomId(): int {
 		return $this->roomId;
 	}
-
 
 	/**
 	 * @param string $roomName
@@ -82,7 +78,6 @@ class TalkRoom implements IQueryRow, JsonSerializable {
 		return $this->roomType;
 	}
 
-
 	/**
 	 * @param string $token
 	 */
@@ -98,7 +93,6 @@ class TalkRoom implements IQueryRow, JsonSerializable {
 	public function getToken(): string {
 		return $this->token;
 	}
-
 
 	/**
 	 * @param array $data

--- a/lib/RelatedResourceProviders/CalendarRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/CalendarRelatedResourceProvider.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\RelatedResourceProviders;
 
@@ -88,7 +86,6 @@ class CalendarRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	public function getItemsAvailableToEntity(FederatedUser $entity): array {
 		switch ($entity->getBasedOn()->getSource()) {
 			case Member::TYPE_USER:
@@ -112,11 +109,8 @@ class CalendarRelatedResourceProvider implements IRelatedResourceProvider {
 		}, $shares);
 	}
 
-
 	public function improveRelatedResource(CirclesManager $circlesManager, IRelatedResource $entry): void {
 	}
-
-
 
 	private function convertToRelatedResource(Calendar $calendar): IRelatedResource {
 		$related = new RelatedResource(self::PROVIDER_ID, $calendar->getId());
@@ -157,7 +151,6 @@ class CalendarRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	/**
 	 * @param RelatedResource $related
 	 * @param CalendarShare $share
@@ -178,7 +171,6 @@ class CalendarRelatedResourceProvider implements IRelatedResourceProvider {
 		} catch (Exception $e) {
 		}
 	}
-
 
 	private function completeShareDetails(CalendarShare $share): void {
 		[$type, $user] = explode('/', substr($share->getSharePrincipalUri(), 11), 2);

--- a/lib/RelatedResourceProviders/DeckRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/DeckRelatedResourceProvider.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\RelatedResourceProviders;
 
@@ -54,7 +52,6 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 		return [];
 	}
 
-
 	/**
 	 * @param string $itemId
 	 *
@@ -81,7 +78,6 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	public function getItemsAvailableToEntity(FederatedUser $entity): array {
 		switch ($entity->getBasedOn()->getSource()) {
 			case Member::TYPE_USER:
@@ -95,7 +91,6 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 			case Member::TYPE_CIRCLE:
 				// We skip circle shares for related resources as they are covered by team resources
 				return [];
-
 			default:
 				return [];
 		}
@@ -104,7 +99,6 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 			return (string)$board->getBoardId();
 		}, $shares);
 	}
-
 
 	public function improveRelatedResource(CirclesManager $circlesManager, IRelatedResource $entry): void {
 	}
@@ -142,7 +136,6 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	/**
 	 * @param RelatedResource $related
 	 * @param DeckShare $share
@@ -163,7 +156,6 @@ class DeckRelatedResourceProvider implements IRelatedResourceProvider {
 		} catch (Exception $e) {
 		}
 	}
-
 
 	/**
 	 * @param CirclesManager $circlesManager

--- a/lib/RelatedResourceProviders/FilesRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/FilesRelatedResourceProvider.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\RelatedResourceProviders;
 
@@ -50,11 +48,9 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 		return self::PROVIDER_ID;
 	}
 
-
 	public function loadWeightCalculator(): array {
 		return [];
 	}
-
 
 	public function getRelatedFromItem(CirclesManager $circlesManager, string $itemId): ?IRelatedResource {
 		$itemId = (int)$itemId;
@@ -93,7 +89,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	public function getItemsAvailableToEntity(FederatedUser $entity): array {
 		switch ($entity->getBasedOn()->getSource()) {
 			case Member::TYPE_USER:
@@ -107,7 +102,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 			case Member::TYPE_CIRCLE:
 				// We skip circle shares for related resources as they are covered by team resources
 				return [];
-
 			default:
 				return [];
 		}
@@ -116,7 +110,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 			return (string)$share->getFileId();
 		}, $shares);
 	}
-
 
 	public function improveRelatedResource(CirclesManager $circlesManager, IRelatedResource $entry): void {
 		$current = $circlesManager->getCurrentFederatedUser();
@@ -131,7 +124,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 			$entry->setTitle($paths[0]->getName());
 		}
 	}
-
 
 	private function convertToRelatedResource(FilesShare $share): IRelatedResource {
 		$related = new RelatedResource(self::PROVIDER_ID, (string)$share->getFileId());
@@ -173,7 +165,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	/**
 	 * @param list<array{id:int,type?:string}> $itemEntries
 	 */
@@ -205,7 +196,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 
 		return $related;
 	}
-
 
 	/**
 	 * @param int $itemId
@@ -248,7 +238,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 		return $itemEntries;
 	}
 
-
 	/**
 	 * @param RelatedResource $related
 	 * @param FilesShare $share
@@ -285,7 +274,6 @@ class FilesRelatedResourceProvider implements IRelatedResourceProvider {
 		} catch (Exception $e) {
 		}
 	}
-
 
 	/**
 	 * @param int $shareType

--- a/lib/RelatedResourceProviders/GroupFoldersRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/GroupFoldersRelatedResourceProvider.php
@@ -99,7 +99,6 @@ class GroupFoldersRelatedResourceProvider implements IRelatedResourceProvider {
 		return $items;
 	}
 
-
 	public function improveRelatedResource(CirclesManager $circlesManager, IRelatedResource $entry): void {
 	}
 
@@ -160,7 +159,6 @@ class GroupFoldersRelatedResourceProvider implements IRelatedResourceProvider {
 				->setAsGroupShared();
 		}
 	}
-
 
 	/**
 	 * @param int $folderId

--- a/lib/RelatedResourceProviders/TalkRelatedResourceProvider.php
+++ b/lib/RelatedResourceProviders/TalkRelatedResourceProvider.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\RelatedResourceProviders;
 
@@ -41,16 +39,13 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 	) {
 	}
 
-
 	public function getProviderId(): string {
 		return self::PROVIDER_ID;
 	}
 
-
 	public function loadWeightCalculator(): array {
 		return [];
 	}
-
 
 	/**
 	 * @param string $itemId
@@ -84,7 +79,6 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 
 		return $related;
 	}
-
 
 	public function improveRelatedResource(CirclesManager $circlesManager, IRelatedResource $entry): void {
 		if (!$entry->hasMeta('1on1')) {
@@ -125,7 +119,6 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 			case Member::TYPE_CIRCLE:
 				// We skip circle shares for related resources as they are covered by team resources
 				return [];
-
 			default:
 				return [];
 		}
@@ -134,7 +127,6 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 			return $room->getToken();
 		}, $shares);
 	}
-
 
 	private function convertToRelatedResource(TalkRoom $share): IRelatedResource {
 		$url = '';
@@ -175,7 +167,6 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 		return $related;
 	}
 
-
 	/**
 	 * @param RelatedResource $related
 	 * @param TalkActor $actor
@@ -196,7 +187,6 @@ class TalkRelatedResourceProvider implements IRelatedResourceProvider {
 		} catch (Exception $e) {
 		}
 	}
-
 
 	/**
 	 * @param TalkActor $actor

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Service;
 

--- a/lib/Service/RelatedService.php
+++ b/lib/Service/RelatedService.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 namespace OCA\RelatedResources\Service;
 
 use Exception;
@@ -85,7 +84,6 @@ class RelatedService {
 		}
 	}
 
-
 	/**
 	 * @param string $providerId
 	 * @param string $itemId
@@ -115,7 +113,6 @@ class RelatedService {
 
 		return ($chunk > -1) ? array_slice($result, 0, $chunk) : $result;
 	}
-
 
 	/**
 	 * Main method that will return resource related an item (identified by providerId and itemId)
@@ -215,7 +212,6 @@ class RelatedService {
 		return $result;
 	}
 
-
 	/**
 	 * get the RelatedResource from an item. including all recipient/virtual groups
 	 *
@@ -245,7 +241,6 @@ class RelatedService {
 
 		return $result;
 	}
-
 
 	/**
 	 * @param string $providerId
@@ -309,7 +304,6 @@ class RelatedService {
 	): string {
 		return 'relatedFromItem/' . $providerId . '::' . $itemId;
 	}
-
 
 	/**
 	 * @param IRelatedResourceProvider $provider
@@ -399,7 +393,6 @@ class RelatedService {
 		return 'availableItem/' . $providerId . '::' . $singleId;
 	}
 
-
 	/**
 	 * @param RelatedResource $current
 	 * @param RelatedResource[] $result
@@ -429,7 +422,6 @@ class RelatedService {
 			return false;
 		});
 	}
-
 
 	/**
 	 * @param IRelatedResource[] $result
@@ -465,7 +457,6 @@ class RelatedService {
 			return false;
 		});
 	}
-
 
 	/**
 	 * @param IRelatedResource[] $result
@@ -525,7 +516,6 @@ class RelatedService {
 		return $this->weightCalculators;
 	}
 
-
 	/**
 	 * @return IRelatedResourceProvider[]
 	 */
@@ -537,7 +527,6 @@ class RelatedService {
 		} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 			$this->logger->notice($e->getMessage());
 		}
-
 
 		try {
 			$providers[] = Server::get(AccountRelatedResourceProvider::class);

--- a/lib/Tools/Db/ExtendedQueryBuilder.php
+++ b/lib/Tools/Db/ExtendedQueryBuilder.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Db;
 
@@ -33,7 +31,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	private string $defaultSelectAlias = '';
 	private array $defaultValues = [];
 
-
 	public function __construct() {
 		parent::__construct(
 			Server::get(ConnectionAdapter::class),
@@ -41,7 +38,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 			Server::get(LoggerInterface::class)
 		);
 	}
-
 
 	/**
 	 * @param string $alias
@@ -60,7 +56,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	public function getDefaultSelectAlias(): string {
 		return $this->defaultSelectAlias;
 	}
-
 
 	/**
 	 * @return array
@@ -106,7 +101,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 			$this->setMaxResults($limit);
 		}
 	}
-
 
 	/**
 	 * Limit the request to the Id
@@ -180,7 +174,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		$this->limit('token', $token);
 	}
 
-
 	/**
 	 * Limit the request to the creation
 	 *
@@ -197,7 +190,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param string $field
@@ -221,7 +213,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		$this->andWhere($orX);
 	}
-
 
 	/**
 	 * @param int $timestamp
@@ -249,7 +240,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		$this->andWhere($orX);
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -263,7 +253,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		$this->andWhere($expr->iLike($field, $this->createNamedParameter($value)));
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -273,7 +262,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	public function like(string $field, string $value, string $alias = '', bool $cs = true): void {
 		$this->andWhere($this->exprLike($field, $value, $alias, $cs));
 	}
-
 
 	/**
 	 * @param string $field
@@ -369,7 +357,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		$this->andWhere($this->exprLt($field, $value, $lte, $alias));
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -418,7 +405,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $expr->eq($field, $this->createNamedParameter($value, IQueryBuilder::PARAM_INT));
 	}
-
 
 	/**
 	 * @param string $field
@@ -489,7 +475,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		return $orX;
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param array $values
@@ -520,7 +505,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		return $andX;
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param array $values
@@ -539,7 +523,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 			$field, $this->createNamedParameter($values, IQueryBuilder::PARAM_STR_ARRAY)
 		);
 	}
-
 
 	/**
 	 * @param string $field
@@ -560,7 +543,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 			$this->createNamedParameter(0, IQueryBuilder::PARAM_INT)
 		);
 	}
-
 
 	/**
 	 * @param string $field
@@ -606,7 +588,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		}
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -616,7 +597,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	public function unlike(string $field, string $value, string $alias = '', bool $cs = true): void {
 		$this->andWhere($this->exprUnlike($field, $value, $alias, $cs));
 	}
-
 
 	/**
 	 * @param string $field
@@ -692,7 +672,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		$this->andWhere($this->exprFilterBitwise($field, $flag, $alias));
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param string $value
@@ -715,7 +694,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 			return $expr->notLike($func->lower($field), $func->lower($this->createNamedParameter($value)));
 		}
 	}
-
 
 	/**
 	 * @param string $field
@@ -743,7 +721,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		}
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param int $value
@@ -760,7 +737,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $expr->neq($field, $this->createNamedParameter($value, IQueryBuilder::PARAM_INT));
 	}
-
 
 	/**
 	 * @param string $field
@@ -831,7 +807,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		return $andX;
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param array $values
@@ -862,7 +837,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		return $orX;
 	}
 
-
 	/**
 	 * @param string $field
 	 * @param array $values
@@ -879,7 +853,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $expr->notIn($field, $this->createNamedParameter($values, IQueryBuilder::PARAM_STR_ARRAY));
 	}
-
 
 	/**
 	 * @param string $field
@@ -900,7 +873,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 			$this->createNamedParameter(0, IQueryBuilder::PARAM_INT)
 		);
 	}
-
 
 	/**
 	 * @param string $object
@@ -923,7 +895,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	public function asItems(string $object, array $params = []): array {
 		return $this->getRows([$this, 'parseSimpleSelectSql'], $object, $params);
 	}
-
 
 	/**
 	 * @param string $field
@@ -950,7 +921,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $this->getRows([$this, 'parseSimpleSelectSql'], $field, $params);
 	}
-
 
 	/**
 	 * @param array $data
@@ -994,7 +964,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 		return $item;
 	}
 
-
 	/**
 	 * @param callable $method
 	 * @param string $object
@@ -1014,7 +983,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $method($data, $this, $object, $params);
 	}
-
 
 	/**
 	 * @param callable $method
@@ -1036,7 +1004,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $rows;
 	}
-
 
 	/**
 	 * @param string $table
@@ -1066,7 +1033,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 		return $this;
 	}
-
 
 	/**
 	 * @param array $fields

--- a/lib/Tools/Db/IQueryRow.php
+++ b/lib/Tools/Db/IQueryRow.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Db;
 

--- a/lib/Tools/Exceptions/ArrayNotFoundException.php
+++ b/lib/Tools/Exceptions/ArrayNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/Exceptions/DateTimeException.php
+++ b/lib/Tools/Exceptions/DateTimeException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/Exceptions/InvalidItemException.php
+++ b/lib/Tools/Exceptions/InvalidItemException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/Exceptions/ItemNotFoundException.php
+++ b/lib/Tools/Exceptions/ItemNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/Exceptions/MalformedArrayException.php
+++ b/lib/Tools/Exceptions/MalformedArrayException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/Exceptions/RowNotFoundException.php
+++ b/lib/Tools/Exceptions/RowNotFoundException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/Exceptions/UnknownTypeException.php
+++ b/lib/Tools/Exceptions/UnknownTypeException.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Exceptions;
 

--- a/lib/Tools/IDeserializable.php
+++ b/lib/Tools/IDeserializable.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools;
 

--- a/lib/Tools/Traits/TArrayTools.php
+++ b/lib/Tools/Traits/TArrayTools.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Traits;
 
@@ -25,7 +23,6 @@ trait TArrayTools {
 	public static $TYPE_BOOLEAN = 'Boolean';
 	public static $TYPE_INTEGER = 'Integer';
 	public static $TYPE_SERIALIZABLE = 'Serializable';
-
 
 	/**
 	 * @param string $k
@@ -60,7 +57,6 @@ trait TArrayTools {
 		return (string)$arr[$k];
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param array $arr
@@ -94,7 +90,6 @@ trait TArrayTools {
 		return intval($arr[$k]);
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param array $arr
@@ -127,7 +122,6 @@ trait TArrayTools {
 
 		return intval($arr[$k]);
 	}
-
 
 	/**
 	 * @param string $k
@@ -170,7 +164,6 @@ trait TArrayTools {
 		return $default;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param array $arr
@@ -194,7 +187,6 @@ trait TArrayTools {
 
 		return $arr[$k];
 	}
-
 
 	/**
 	 * @param string $k
@@ -238,7 +230,6 @@ trait TArrayTools {
 		return $r;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param array $arr
@@ -267,7 +258,6 @@ trait TArrayTools {
 		return false;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param array $arr
@@ -294,7 +284,6 @@ trait TArrayTools {
 		return $r;
 	}
 
-
 	/**
 	 * @param string $k
 	 * @param string $value
@@ -316,7 +305,6 @@ trait TArrayTools {
 
 		throw new ArrayNotFoundException();
 	}
-
 
 	/**
 	 * @param string $key
@@ -373,7 +361,6 @@ trait TArrayTools {
 		throw new ItemNotFoundException();
 	}
 
-
 	/**
 	 * @param array $keys
 	 * @param array $arr
@@ -389,7 +376,6 @@ trait TArrayTools {
 			}
 		}
 	}
-
 
 	/**
 	 * @param array $arr

--- a/lib/Tools/Traits/TDeserialize.php
+++ b/lib/Tools/Traits/TDeserialize.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Traits;
 
@@ -36,7 +34,6 @@ trait TDeserialize {
 		return json_decode(json_encode($data), true);
 	}
 
-
 	/**
 	 * @param array $data
 	 * @param string $class
@@ -61,7 +58,6 @@ trait TDeserialize {
 
 		return $item;
 	}
-
 
 	/**
 	 * force deserialize without checking for implementation of IDeserializable.
@@ -122,7 +118,6 @@ trait TDeserialize {
 
 		return $arr;
 	}
-
 
 	/**
 	 * @param string $json

--- a/lib/Tools/Traits/TStringTools.php
+++ b/lib/Tools/Traits/TStringTools.php
@@ -2,12 +2,10 @@
 
 declare(strict_types=1);
 
-
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
 
 namespace OCA\RelatedResources\Tools\Traits;
 
@@ -16,7 +14,6 @@ use Exception;
 
 trait TStringTools {
 	use TArrayTools;
-
 
 	/**
 	 * @param int $length
@@ -37,7 +34,6 @@ trait TStringTools {
 
 		return $str;
 	}
-
 
 	/**
 	 * Generate uuid: 2b5a7a87-8db1-445f-a17b-405790f91c80
@@ -63,7 +59,6 @@ trait TStringTools {
 
 		return $uuid;
 	}
-
 
 	/**
 	 * @param string $line
@@ -104,7 +99,6 @@ trait TStringTools {
 		return substr($str1, 0, $i);
 	}
 
-
 	/**
 	 * @param string $line
 	 * @param array $params
@@ -120,7 +114,6 @@ trait TStringTools {
 		return $line;
 	}
 
-
 	/**
 	 * @param int $words
 	 *
@@ -134,7 +127,6 @@ trait TStringTools {
 
 		return implode(' ', $sentence);
 	}
-
 
 	/**
 	 * @param int $length
@@ -154,7 +146,6 @@ trait TStringTools {
 		return implode('', $word);
 	}
 
-
 	/**
 	 * @param int $bytes
 	 *
@@ -170,7 +161,6 @@ trait TStringTools {
 
 		return round($bytes / pow(1024, $e), 2) . ' ' . $s[$e];
 	}
-
 
 	/**
 	 * @param int $first

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="lib/AppInfo/Application.php">
-    <InvalidArgument>
-      <code>registerEventListener(LoadSidebar::class, LoadSidebarScript::class)</code>
-    </InvalidArgument>
+    <InvalidArgument/>
   </file>
   <file src="lib/Tools/Traits/TStringTools.php">
     <InvalidArrayOffset>
-      <code>$s[$e]</code>
+      <code><![CDATA[$s[$e]]]></code>
     </InvalidArrayOffset>
   </file>
 </files>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
-  <file src="lib/AppInfo/Application.php">
-    <InvalidArgument/>
-  </file>
   <file src="lib/Tools/Traits/TStringTools.php">
     <InvalidArrayOffset>
       <code><![CDATA[$s[$e]]]></code>

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -1011,3 +1011,7 @@ namespace OC\Files\Storage\Wrapper{
 namespace OC\AppFramework\Middleware\Security\Exceptions {
 	class NotLoggedInException extends \Exception {}
 }
+
+namespace OCA\Files\Event {
+	class LoadSidebar extends \OCP\EventDispatcher\Event {}
+}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -543,6 +543,7 @@ namespace OC\DB\QueryBuilder {
         public function getColumnName($column, $tableAlias = '') { }
         public function quoteAlias($alias) { }
 		public function runAcrossAllShards(): self { }
+		public function forUpdate(): self { }
 		public function getOutputColumns(): array {}
     }
 }


### PR DESCRIPTION
https://github.com/nextcloud/related_resources/actions/runs/29601362971/job/87953999682

```
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires nextcloud/ocp dev-stable34 -> satisfiable by nextcloud/ocp[dev-stable34].
    - nextcloud/ocp dev-stable34 requires psr/log ^3.0.2 -> found psr/log[3.0.2] but the package is fixed to 1.1.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

  Problem 1
    - Root composer.json requires nextcloud/ocp dev-stable34 -> satisfiable by nextcloud/ocp[dev-stable34].
    - nextcloud/ocp dev-stable34 requires psr/log ^3.0.2 -> found psr/log[3.0.2] but the package is fixed to 1.1.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
Error: Process completed with exit code 2.

```

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
