### PR TITLE
ci(psalm): Fix nextcloud/ocp update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"classmap-authoritative": true,
 		"autoloader-suffix": "RelatedResources",
 		"platform": {
-			"php": "8.2.27"
+			"php": "8.3.16"
 		}
 	},
 	"authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bc24b97f414df4b7ffe231185d403df",
+    "content-hash": "3598e49183afdf4b5ee0effe03fb8c01",
     "packages": [],
     "packages-dev": [
         {
@@ -1795,16 +1795,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b01a80e20e17c3bf3c5d8a0246289ec465fd0b0f"
+                "reference": "ab0d7a274b606f57944ca0a0c2452aa34e39d1ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b01a80e20e17c3bf3c5d8a0246289ec465fd0b0f",
-                "reference": "b01a80e20e17c3bf3c5d8a0246289ec465fd0b0f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ab0d7a274b606f57944ca0a0c2452aa34e39d1ff",
+                "reference": "ab0d7a274b606f57944ca0a0c2452aa34e39d1ff",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1 || ~8.2 || ~8.3 || ~8.4 || ~8.5",
+                "php": "~8.3 || ~8.4 || ~8.5",
                 "psr/clock": "^1.0",
                 "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
@@ -1837,7 +1837,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-06-04T02:37:15+00:00"
+            "time": "2026-07-18T01:22:51+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -5251,7 +5251,7 @@
     "platform": {},
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2.27"
+        "php": "8.3.16"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
https://github.com/nextcloud/related_resources/actions/runs/29601362971/job/87953999644

```
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires nextcloud/ocp dev-master -> satisfiable by nextcloud/ocp[dev-master].
    - nextcloud/ocp dev-master requires php ~8.3 || ~8.4 || ~8.5 -> your php version (8.2.27; overridden via config.platform, actual: 8.2.31) does not satisfy that requirement.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

  Problem 1
    - Root composer.json requires nextcloud/ocp dev-master -> satisfiable by nextcloud/ocp[dev-master].
    - nextcloud/ocp dev-master requires php ~8.3 || ~8.4 || ~8.5 -> your php version (8.2.27; overridden via config.platform, actual: 8.2.31) does not satisfy that requirement.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
Error: Process completed with exit code 2.

```

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
